### PR TITLE
fix: 修复数据返回成功时 info.error 也会变化的问题

### DIFF
--- a/packages/model/src/operations/gqlMutation.ts
+++ b/packages/model/src/operations/gqlMutation.ts
@@ -41,14 +41,14 @@ export function createGQLMutation<ModelType, DataType>(
         info,
         mutate(params: any) {
             info.loading = true;
-            info.error = null;
+            info.error = undefined;
 
             return client.mutate<DataType>({
                 // TODO
                 mutation: '' as unknown as any,
                 variables: variables(params),
             }).then(data => {
-                info.error = null;
+                info.error = undefined;
                 if (data) {
                     info.data = data;
                 }

--- a/packages/model/src/operations/restMutation.ts
+++ b/packages/model/src/operations/restMutation.ts
@@ -39,7 +39,7 @@ export function createRestMutation<ModelType, DataType>(
 
     function mutate<T extends Record<string, any>>(params: T) {
         info.loading = true;
-        info.error = null;
+        info.error = undefined;
         return client!.mutate<DataType>({
             url: url(variables(params)),
             headers: option.headers,
@@ -47,7 +47,7 @@ export function createRestMutation<ModelType, DataType>(
             variables: variables(params),
             timeout: option.timeout,
         }).then(data => {
-            info.error = null;
+            info.error = undefined;
             if (data) {
                 info.data = data;
             }

--- a/packages/model/src/operations/restQuery.ts
+++ b/packages/model/src/operations/restQuery.ts
@@ -53,7 +53,7 @@ export function createRestQuery<ModelType, DataType>(
             );
             subject.subscribe({
                 next: (data) => {
-                    info.error = null;
+                    info.error = undefined;
                     if (data) {
                         info.data = data;
                     }
@@ -112,7 +112,7 @@ export function createRestQuery<ModelType, DataType>(
             );
             observable.subscribe({
                 next: (data) => {
-                    info.error = null;
+                    info.error = undefined;
                     info.data = data && option.updateQuery ? option.updateQuery(info.data, data) : data;
                     info.loading = false;
                     resolve(undefined);


### PR DESCRIPTION
info中 error 一开始是 undefined ，请求后变为 null ，`watch(() => info.error)` 会触发