### PR TITLE
fix: DEFAULT_OPTIONS

### DIFF
--- a/packages/model/src/clients/client-factory.ts
+++ b/packages/model/src/clients/client-factory.ts
@@ -19,9 +19,9 @@ class TimeoutError extends Error {
 }
 
 const DEFAULT_OPTIONS: ClientOptions = {
-    method: 'GET',
+    method: 'POST',
     headers: {
-        "content-type": 'application/x-www-form-urlencoded'
+        'content-type': 'application/json',
     },
     timeout: 60 * 1000,
     credentials: 'include',


### PR DESCRIPTION
如果是get请求，后续createRequestInfo会改content-type为urlencoded...，但是后续代码不会修改post请求的content-type，所以目前会有post请求content-type为urlencoded...的情况。